### PR TITLE
README.md: typo in uapi, part ii

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Note:
 1. Patches present in base will be removed once merged in mainline kernel.
 2. Patches present in features are dynamic in nature, they may change frequently and removed once merged in drm-tip.
 3. Patches present in features will use prelim uapi to aviod conflict in updates, once patches are merged in drm-tip, uapi will change from prelim to normal.
-4. prelim upai will be maintained at [drm-uapi-helper](https://github.com/intel-gpu/drm-uapi-helper/tree/xe).
+4. prelim uapi will be maintained at [drm-uapi-helper](https://github.com/intel-gpu/drm-uapi-helper/tree/xe).
 
 # Usage
 backport.sh < options >


### PR DESCRIPTION
well, overlooked preceeding uapi->uapi typo :)